### PR TITLE
Feature ts on records

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -617,7 +617,7 @@ public class FlinkKafkaProducer011<IN>
 			byte[] bytes = o.getId().getBytes();
 			target.put(bytes);
 			target.putChar('=');
-			target.putLong(o.getTimestamp());
+			target.put((""+o.getTimestamp()).getBytes());
 		}
 	}
 
@@ -638,7 +638,7 @@ public class FlinkKafkaProducer011<IN>
 		}
 
 		List<OperatorOutputTimestamp> operatorOutputTimestamps = context.operatorOutputTimestamps();
-		int encondedLengthOfOperatorTimestamps = operatorOutputTimestamps.stream().map(o -> o.getId().getBytes().length + Long.BYTES).reduce(0, Integer::sum);
+		int encondedLengthOfOperatorTimestamps = operatorOutputTimestamps.stream().map(o -> o.getId().getBytes().length + (""+o.getTimestamp()).getBytes().length).reduce(0, Integer::sum);
 		encondedLengthOfOperatorTimestamps += Math.max(2*(operatorOutputTimestamps.size()-1), 0) + 2*operatorOutputTimestamps.size(); //commas and equals
 		ByteBuffer buffer = ByteBuffer.allocate(serializedValue.length + encondedLengthOfOperatorTimestamps + 2);
 		buffer.put(serializedValue);

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.connectors.kafka.internal.metrics.KafkaMetricM
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaDelegatePartitioner;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.streaming.runtime.streamrecord.OperatorOutputTimestamp;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchemaWrapper;
 import org.apache.flink.util.ExceptionUtils;
@@ -67,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -608,6 +610,16 @@ public class FlinkKafkaProducer011<IN>
 
 		super.open(configuration);
 	}
+	private void serializeOperatorTimestampsIntoByteBuffer(List<OperatorOutputTimestamp> operatorOutputTimestamps, ByteBuffer target) {
+		boolean first = true;
+		for(OperatorOutputTimestamp o : operatorOutputTimestamps){
+			if(first) first = false ; else target.putChar(',');
+			byte[] bytes = o.getId().getBytes();
+			target.put(bytes);
+			target.putChar('=');
+			target.putLong(o.getTimestamp());
+		}
+	}
 
 	@Override
 	public void invoke(KafkaTransactionState transaction, IN next, Context context) throws FlinkKafka011Exception {
@@ -624,6 +636,15 @@ public class FlinkKafkaProducer011<IN>
 		if (this.writeTimestampToKafka) {
 			timestamp = context.timestamp();
 		}
+
+		List<OperatorOutputTimestamp> operatorOutputTimestamps = context.operatorOutputTimestamps();
+		int encondedLengthOfOperatorTimestamps = operatorOutputTimestamps.stream().map(o -> o.getId().getBytes().length + Long.BYTES).reduce(0, Integer::sum);
+		encondedLengthOfOperatorTimestamps += Math.max(2*(operatorOutputTimestamps.size()-1), 0) + 2*operatorOutputTimestamps.size(); //commas and equals
+		ByteBuffer buffer = ByteBuffer.allocate(serializedValue.length + encondedLengthOfOperatorTimestamps + 2);
+		buffer.put(serializedValue);
+		buffer.putChar('$');
+		serializeOperatorTimestampsIntoByteBuffer(operatorOutputTimestamps, buffer);
+		serializedValue = buffer.array();
 
 		ProducerRecord<byte[], byte[]> record;
 		int[] partitions = topicPartitionsMap.get(targetTopic);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkContextUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkContextUtil.java
@@ -19,6 +19,9 @@
 package org.apache.flink.streaming.api.functions.sink;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.runtime.streamrecord.OperatorOutputTimestamp;
+
+import java.util.List;
 
 /**
  * Utility for creating Sink {@link SinkFunction.Context Contexts}.
@@ -45,6 +48,11 @@ public class SinkContextUtil {
 			@Override
 			public Long timestamp() {
 				return timestamp;
+			}
+
+			@Override
+			public List<OperatorOutputTimestamp> operatorOutputTimestamps() {
+				throw  new RuntimeException("Not implemented");
 			}
 		};
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -19,8 +19,10 @@ package org.apache.flink.streaming.api.functions.sink;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.streaming.runtime.streamrecord.OperatorOutputTimestamp;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Interface for implementing user defined sink functionality.
@@ -76,5 +78,7 @@ public interface SinkFunction<IN> extends Function, Serializable {
 		 * have an assigned timestamp.
 		 */
 		Long timestamp();
+
+		List<OperatorOutputTimestamp> operatorOutputTimestamps();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -172,7 +172,8 @@ public abstract class AbstractStreamOperator<OUT>
 		this.config = config;
 		try {
 			OperatorMetricGroup operatorMetricGroup = environment.getMetricGroup().addOperator(config.getOperatorID(), config.getOperatorName());
-			this.output = new CountingOutput(output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
+			this.output = new EmissionTimestamperOutput(output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter(), runtimeContext.getOperatorUniqueID());
+			//this.output = new CountingOutput(output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
 			if (config.isChainStart()) {
 				operatorMetricGroup.getIOMetricGroup().reuseInputMetricsForTask();
 			}
@@ -183,7 +184,8 @@ public abstract class AbstractStreamOperator<OUT>
 		} catch (Exception e) {
 			LOG.warn("An error occurred while instantiating task metrics.", e);
 			this.metrics = UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();
-			this.output = output;
+			//this.output = output;
+			this.output = new EmissionTimestamperOutput(output, runtimeContext.getOperatorUniqueID());
 		}
 
 		try {
@@ -660,6 +662,56 @@ public abstract class AbstractStreamOperator<OUT>
 	}
 
 	// ----------------------- Helper classes -----------------------
+
+	/**
+	 * Wrapping {@link Output} that adds an emission timestamp to records.
+	 */
+	public static class EmissionTimestamperOutput<OUT> implements Output<StreamRecord<OUT>> {
+		private final Output<StreamRecord<OUT>> output;
+		private final String operatorId;
+
+		public EmissionTimestamperOutput(Output<StreamRecord<OUT>> output, Counter counter, String operatorId) {
+			LOG.info("CREATED INSTANCE OF EMISSION TIMESTAMPER");
+			this.output = new CountingOutput<>(output, counter);
+			this.operatorId = operatorId;
+		}
+		public EmissionTimestamperOutput(Output<StreamRecord<OUT>> output, String operatorId) {
+			LOG.info("CREATED INSTANCE OF EMISSION TIMESTAMPER");
+			this.output = output;
+			this.operatorId = operatorId;
+		}
+
+		@Override
+		public void emitWatermark(Watermark mark) {
+			output.emitWatermark(mark);
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) {
+			output.emitLatencyMarker(latencyMarker);
+		}
+
+		@Override
+		public void collect(StreamRecord<OUT> record) {
+			LOG.info("Add ts to record: (" + operatorId+ ", "+ System.currentTimeMillis() + ") with " + record.getOperatorOutputTimestamps().size() + "elements");
+			record.appendTime(operatorId,System.currentTimeMillis());
+			LOG.info("Now with " + record.getOperatorOutputTimestamps().size());
+			output.collect(record);
+		}
+
+		@Override
+		public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+			LOG.info("Add ts to record: (" + operatorId+ ", "+ System.currentTimeMillis() + "), with " + record.getOperatorOutputTimestamps().size() + "elements");
+			record.appendTime(operatorId,System.currentTimeMillis());
+			LOG.info("Now with " + record.getOperatorOutputTimestamps().size());
+			output.collect(outputTag, record);
+		}
+
+		@Override
+		public void close() {
+			output.close();
+		}
+	}
 
 	/**
 	 * Wrapping {@link Output} that updates metrics on the number of emitted elements.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
@@ -129,7 +129,7 @@ public class KeyedProcessOperator<K, IN, OUT>
 				throw new IllegalArgumentException("OutputTag must not be null.");
 			}
 
-			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp(), element.getOperatorOutputTimestamps()));
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ProcessOperator.java
@@ -99,7 +99,7 @@ public class ProcessOperator<IN, OUT>
 			if (outputTag == null) {
 				throw new IllegalArgumentException("OutputTag must not be null.");
 			}
-			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp(), element.getOperatorOutputTimestamps()));
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -38,6 +38,8 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
 
 	private transient SimpleContext sinkContext;
 
+	private String operatorId;
+
 	/** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
 	private long currentWatermark = Long.MIN_VALUE;
 
@@ -55,6 +57,9 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
 
 	@Override
 	public void processElement(StreamRecord<IN> element) throws Exception {
+		if(operatorId == null)
+			this.operatorId = getOperatorID().toString();
+		element.getOperatorOutputTimestamps().add(new OperatorOutputTimestamp(this.operatorId, System.currentTimeMillis()));
 		sinkContext.element = element;
 		userFunction.invoke(element.getValue(), sinkContext);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -21,8 +21,11 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.OperatorOutputTimestamp;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+
+import java.util.List;
 
 /**
  * A {@link StreamOperator} for executing {@link SinkFunction SinkFunctions}.
@@ -96,6 +99,11 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
 				return element.getTimestamp();
 			}
 			return null;
+		}
+
+		@Override
+		public List<OperatorOutputTimestamp> operatorOutputTimestamps() {
+			return element.getOperatorOutputTimestamps();
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSourceContexts.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSourceContexts.java
@@ -101,7 +101,7 @@ public class StreamSourceContexts {
 		@Override
 		public void collect(T element) {
 			synchronized (lock) {
-				output.collect(reuse.replace(element));
+				output.collect(reuse.replaceAndClearEmissionTimestamps(element));
 			}
 		}
 
@@ -173,7 +173,7 @@ public class StreamSourceContexts {
 		@Override
 		protected void processAndCollect(T element) {
 			lastRecordTime = this.timeService.getCurrentProcessingTime();
-			output.collect(reuse.replace(element, lastRecordTime));
+			output.collect(reuse.replaceAndClearEmissionTimestamps(element, lastRecordTime));
 
 			// this is to avoid lock contention in the lockingObject by
 			// sending the watermark before the firing of the watermark

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.runtime.io;
 
+import com.esotericsoftware.minlog.Log;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.metrics.Gauge;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/OperatorOutputTimestamp.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/OperatorOutputTimestamp.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.streaming.runtime.streamrecord;
+
+public class OperatorOutputTimestamp {
+	private String id;
+	private long timestamp;
+
+	public OperatorOutputTimestamp(String id, long timestamp) {
+		this.id = id;
+		this.timestamp = timestamp;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	public void setTimestamp(long timestamp) {
+		this.timestamp = timestamp;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecord.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecord.java
@@ -137,6 +137,12 @@ public final class StreamRecord<T> extends StreamElement {
 		return (StreamRecord<X>) this;
 	}
 
+	public <X> StreamRecord<X> replaceAndClearEmissionTimestamps(X element) {
+		this.value = (T) element;
+		this.operatorOutputTimestamps = new LinkedList<>();
+		return (StreamRecord<X>) this;
+	}
+
 	/**
 	 * Replace the currently stored value by the given new value and the currently stored
 	 * timestamp with the new timestamp. This returns a StreamElement with the generic type
@@ -151,6 +157,15 @@ public final class StreamRecord<T> extends StreamElement {
 		this.timestamp = timestamp;
 		this.value = (T) value;
 		this.hasTimestamp = true;
+
+		return (StreamRecord<X>) this;
+	}
+
+	public <X> StreamRecord<X> replaceAndClearEmissionTimestamps(X value, long timestamp) {
+		this.timestamp = timestamp;
+		this.value = (T) value;
+		this.hasTimestamp = true;
+		this.operatorOutputTimestamps = new LinkedList<>();
 
 		return (StreamRecord<X>) this;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecord.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecord.java
@@ -19,6 +19,9 @@ package org.apache.flink.streaming.runtime.streamrecord;
 
 import org.apache.flink.annotation.Internal;
 
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * One value in a data stream. This stores the value and an optional associated timestamp.
  *
@@ -29,6 +32,8 @@ public final class StreamRecord<T> extends StreamElement {
 
 	/** The actual value held by this record. */
 	private T value;
+
+	private List<OperatorOutputTimestamp> operatorOutputTimestamps;
 
 	/** The timestamp of the record. */
 	private long timestamp;
@@ -41,6 +46,7 @@ public final class StreamRecord<T> extends StreamElement {
 	 */
 	public StreamRecord(T value) {
 		this.value = value;
+		this.operatorOutputTimestamps = new LinkedList<>();
 	}
 
 	/**
@@ -54,6 +60,26 @@ public final class StreamRecord<T> extends StreamElement {
 		this.value = value;
 		this.timestamp = timestamp;
 		this.hasTimestamp = true;
+		this.operatorOutputTimestamps = new LinkedList<>();
+	}
+
+	/**
+	 * Creates a new StreamRecord wrapping the given value. The timestamp is set to the
+	 * given timestamp.
+	 *
+	 * @param value The value to wrap in this {@link StreamRecord}
+	 * @param timestamp The timestamp in milliseconds
+	 */
+	public StreamRecord(T value, long timestamp, List<OperatorOutputTimestamp> operatorOutputTimestamps) {
+		this.value = value;
+		this.timestamp = timestamp;
+		this.hasTimestamp = true;
+		this.operatorOutputTimestamps = operatorOutputTimestamps;
+	}
+
+	public StreamRecord(T value, List<OperatorOutputTimestamp> operatorOutputTimestampList) {
+		this.value = value;
+		this.operatorOutputTimestamps = operatorOutputTimestampList;
 	}
 
 	// ------------------------------------------------------------------------
@@ -87,6 +113,10 @@ public final class StreamRecord<T> extends StreamElement {
 	 */
 	public boolean hasTimestamp() {
 		return hasTimestamp;
+	}
+
+	public List<OperatorOutputTimestamp> getOperatorOutputTimestamps(){
+		return operatorOutputTimestamps;
 	}
 
 	// ------------------------------------------------------------------------
@@ -125,6 +155,23 @@ public final class StreamRecord<T> extends StreamElement {
 		return (StreamRecord<X>) this;
 	}
 
+	@SuppressWarnings("unchecked")
+	public <X> StreamRecord<X> replace(X element, List<OperatorOutputTimestamp> operatorOutputTimestamps) {
+		this.operatorOutputTimestamps = operatorOutputTimestamps;
+		this.value = (T) element;
+		return (StreamRecord<X>) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public <X> StreamRecord<X> replace(X value, long timestamp, List<OperatorOutputTimestamp> operatorOutputTimestamps) {
+		this.operatorOutputTimestamps = operatorOutputTimestamps;
+		this.timestamp = timestamp;
+		this.value = (T) value;
+		this.hasTimestamp = true;
+
+		return (StreamRecord<X>) this;
+	}
+
 	public void setTimestamp(long timestamp) {
 		this.timestamp = timestamp;
 		this.hasTimestamp = true;
@@ -132,6 +179,10 @@ public final class StreamRecord<T> extends StreamElement {
 
 	public void eraseTimestamp() {
 		this.hasTimestamp = false;
+	}
+
+	public void appendTime(String operatorId, long ts){
+		this.operatorOutputTimestamps.add(new OperatorOutputTimestamp(operatorId, ts));
 	}
 
 	// ------------------------------------------------------------------------
@@ -146,6 +197,8 @@ public final class StreamRecord<T> extends StreamElement {
 		StreamRecord<T> copy = new StreamRecord<>(valueCopy);
 		copy.timestamp = this.timestamp;
 		copy.hasTimestamp = this.hasTimestamp;
+		copy.operatorOutputTimestamps = new LinkedList<>();
+		copy.operatorOutputTimestamps.addAll(this.operatorOutputTimestamps);
 		return copy;
 	}
 
@@ -157,6 +210,9 @@ public final class StreamRecord<T> extends StreamElement {
 		target.value = valueCopy;
 		target.timestamp = this.timestamp;
 		target.hasTimestamp = this.hasTimestamp;
+		//Deep copy
+		target.operatorOutputTimestamps = new LinkedList<>();
+		target.operatorOutputTimestamps.addAll(this.operatorOutputTimestamps);
 	}
 
 	// ------------------------------------------------------------------------
@@ -189,4 +245,5 @@ public final class StreamRecord<T> extends StreamElement {
 	public String toString() {
 		return "Record @ " + (hasTimestamp ? timestamp : "(undef)") + " : " + value;
 	}
+
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -191,7 +191,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	/**
 	 * Constructor for initialization, possibly with initial state (recovery / savepoint / etc).
-	 *
+
 	 * @param env The task environment for this task.
 	 */
 	protected StreamTask(Environment env) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
@@ -25,12 +25,14 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketers.Bucketer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketers.SimpleVersionedStringSerializer;
 
+import org.apache.flink.streaming.runtime.streamrecord.OperatorOutputTimestamp;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Tests for {@link Buckets}.
@@ -76,6 +78,11 @@ public class BucketsTest {
 			@Override
 			public Long timestamp() {
 				return expectedTimestamp;
+			}
+
+			@Override
+			public List<OperatorOutputTimestamp> operatorOutputTimestamps() {
+				return null;
 			}
 		});
 	}


### PR DESCRIPTION
## What is the purpose of the change

Use records to track latency through the graph

## Brief change log
- StreamRecord now has additional field, to hold timestamps
- StreamTasks have a collector which attaches these timestamps
- Kafka connector serializes this into the records using "$" as a separator

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

Not documented 
